### PR TITLE
Switch to using ticker as holdings key

### DIFF
--- a/src/Account.ts
+++ b/src/Account.ts
@@ -44,6 +44,7 @@ export class Account implements IAccount {
           .toArray()
           .map((element) => $(element).text().trim().replace(/\n/g, ''));
         let investment: IInvestment = {
+          name: investmentName,
           ticker: array[0],
           unitsHeld: array[2],
           cost: array[5],
@@ -56,7 +57,7 @@ export class Account implements IAccount {
           stockUrl: investmentUrl,
           details: await Investment.details(investmentUrl),
         };
-        account['holdings'][investmentName] = investment;
+        account['holdings'][investment.ticker] = investment;
       }
     }
     return account;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -16,6 +16,8 @@ export interface IInvestments {
 
 export interface IInvestment {
   [key: string]: any;
+  name: string;
+  ticker: string;
   stockType: string;
   stockInfo: string;
   stockLink?: string;
@@ -26,7 +28,6 @@ export interface IInvestment {
   gain: string;
   gainPercentage: string;
   details?: IInvestmentDetails;
-  ticker: string;
 }
 
 export interface IInvestmentDetails {


### PR DESCRIPTION
Investment names are not unique and should not be used as keys. Vanguard funds like `VFEM` and `VUKE` clobber because both come in as `Vanguard Funds plc`.

An array probably makes more sense here, and I'd support that change, but as a quick fix all I've done is switch the key to be the ticker, and I've added the name into the investment object given it wasn't present anywhere else.